### PR TITLE
Fix ISO 8601 timestamp format in ExpandableMealCard test

### DIFF
--- a/frontend/test/components/ExpandableMealCard.test.tsx
+++ b/frontend/test/components/ExpandableMealCard.test.tsx
@@ -26,7 +26,7 @@ describe('ExpandableMealCard', () => {
     raw_description: 'A simple and delicious pasta recipe with fresh ingredients',
     duration: 1800, // 30 minutes in seconds
     posted_at: '2024-01-15T10:00:00Z',
-    cache_expires_at: '2024-01-16T10:000Z',
+    cache_expires_at: '2024-01-16T10:00:00Z',
   };
 
   it('renders disabled state for skipped day', () => {


### PR DESCRIPTION
## Summary
Fixed an invalid ISO 8601 timestamp in the ExpandableMealCard test fixture data.

## Changes
- Corrected `cache_expires_at` timestamp from `'2024-01-16T10:000Z'` to `'2024-01-16T10:00:00Z'`
  - The original timestamp had an invalid time component (`10:000` instead of `10:00:00`)
  - This ensures the test data conforms to proper ISO 8601 format and prevents potential parsing errors

## Details
This was a typo in the test mock data where the seconds component was missing a digit, resulting in an malformed timestamp string. The fix ensures consistency with the other timestamp in the same test fixture (`posted_at: '2024-01-15T10:00:00Z'`).

https://claude.ai/code/session_01H9EW56zF5xhkgvfcwU2Cwv